### PR TITLE
Add Class Alias Autoload

### DIFF
--- a/src/Helpers/ClassAliasAutoloader.php
+++ b/src/Helpers/ClassAliasAutoloader.php
@@ -30,7 +30,6 @@ class ClassAliasAutoloader
     /**
      * Register a new alias loader instance.
      *
-     * @param  \Psy\Shell  $shell
      * @param  string  $classMapPath
      * @return static
      */
@@ -44,7 +43,6 @@ class ClassAliasAutoloader
     /**
      * Create a new alias loader instance.
      *
-     * @param  \Psy\Shell  $shell
      * @param  string  $classMapPath
      * @return void
      */
@@ -68,7 +66,6 @@ class ClassAliasAutoloader
         }
     }
 
-    
     /**
      * Get the class "basename" of the given object / class.
      *

--- a/src/Helpers/ClassAliasAutoloader.php
+++ b/src/Helpers/ClassAliasAutoloader.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace TweakPHP\Client\Helpers;
+
+use Psy\Shell;
+
+class ClassAliasAutoloader
+{
+    /**
+     * The shell instance.
+     *
+     * @var \Psy\Shell
+     */
+    protected $shell;
+
+    /**
+     * All of the discovered classes.
+     *
+     * @var array
+     */
+    protected $classes = [];
+
+    /**
+     * Path to the vendor directory.
+     *
+     * @var string
+     */
+    protected $vendorPath;
+
+    /**
+     * Register a new alias loader instance.
+     *
+     * @param  \Psy\Shell  $shell
+     * @param  string  $classMapPath
+     * @return static
+     */
+    public static function register(Shell $shell, $classMapPath)
+    {
+        return self::tap(new static($shell, $classMapPath), function ($loader) {
+            spl_autoload_register([$loader, 'aliasClass']);
+        });
+    }
+
+    /**
+     * Create a new alias loader instance.
+     *
+     * @param  \Psy\Shell  $shell
+     * @param  string  $classMapPath
+     * @return void
+     */
+    public function __construct(Shell $shell, $classMapPath)
+    {
+        $this->shell = $shell;
+        $this->vendorPath = dirname(dirname($classMapPath));
+
+        $classes = require $classMapPath;
+
+        foreach ($classes as $class => $path) {
+            if (! $this->isAliasable($class, $path)) {
+                continue;
+            }
+
+            $name = $this->class_basename($class);
+
+            if (! isset($this->classes[$name])) {
+                $this->classes[$name] = $class;
+            }
+        }
+    }
+
+    
+    /**
+     * Get the class "basename" of the given object / class.
+     *
+     * @param  string|object  $class
+     * @return string
+     */
+    private function class_basename($class)
+    {
+        $class = is_object($class) ? get_class($class) : $class;
+
+        return basename(str_replace('\\', '/', $class));
+    }
+
+    /**
+     * Find the closest class by name.
+     *
+     * @param  string  $class
+     * @return void
+     */
+    public function aliasClass($class)
+    {
+        if (Str::contains($class, '\\')) {
+            return;
+        }
+
+        $fullName = $this->classes[$class] ?? false;
+
+        if ($fullName) {
+            $this->shell->writeStdout("[!] Aliasing '{$class}' to '{$fullName}' for this Tinker session.\n");
+
+            class_alias($fullName, $class);
+        }
+    }
+
+    /**
+     * Unregister the alias loader instance.
+     *
+     * @return void
+     */
+    public function unregister()
+    {
+        spl_autoload_unregister([$this, 'aliasClass']);
+    }
+
+    /**
+     * Handle the destruction of the instance.
+     *
+     * @return void
+     */
+    public function __destruct()
+    {
+        $this->unregister();
+    }
+
+    /**
+     * Whether a class may be aliased.
+     *
+     * @param  string  $class
+     * @param  string  $path
+     */
+    public function isAliasable($class, $path)
+    {
+        if (! Str::contains($class, '\\')) {
+            return false;
+        }
+
+        if (Str::startsWith($path, $this->vendorPath)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static function tap($value, $callback = null)
+    {
+        if (is_null($callback)) {
+            return new HigherOrderTapProxy($value);
+        }
+
+        $callback($value);
+
+        return $value;
+    }
+}

--- a/src/Helpers/HigherOrderTapProxy.php
+++ b/src/Helpers/HigherOrderTapProxy.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace TweakPHP\Client\Helpers;
+
+class HigherOrderTapProxy
+{
+    /**
+     * The target being tapped.
+     *
+     * @var mixed
+     */
+    public $target;
+
+    /**
+     * Create a new tap proxy instance.
+     *
+     * @param  mixed  $target
+     * @return void
+     */
+    public function __construct($target)
+    {
+        $this->target = $target;
+    }
+
+    /**
+     * Dynamically pass method calls to the target.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        $this->target->{$method}(...$parameters);
+
+        return $this->target;
+    }
+}

--- a/src/Helpers/Str.php
+++ b/src/Helpers/Str.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace TweakPHP\Client\Helpers;
+
+class Str{
+    /**
+     * Determine if a given string contains a given substring.
+     *
+     * @param  string  $haystack
+     * @param  string|iterable<string>  $needles
+     * @param  bool  $ignoreCase
+     * @return bool
+     */
+    public static function contains($haystack, $needles, $ignoreCase = false)
+    {
+        if ($ignoreCase) {
+            $haystack = mb_strtolower($haystack);
+        }
+
+        if (! is_iterable($needles)) {
+            $needles = (array) $needles;
+        }
+
+        foreach ($needles as $needle) {
+            if ($ignoreCase) {
+                $needle = mb_strtolower($needle);
+            }
+
+            if ($needle !== '' && str_contains($haystack, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if a given string starts with a given substring.
+     *
+     * @param  string  $haystack
+     * @param  string|iterable<string>  $needles
+     * @return bool
+     */
+    public static function startsWith($haystack, $needles)
+    {
+        if (! is_iterable($needles)) {
+            $needles = [$needles];
+        }
+
+        foreach ($needles as $needle) {
+            if ((string) $needle !== '' && str_starts_with($haystack, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Helpers/Str.php
+++ b/src/Helpers/Str.php
@@ -2,7 +2,8 @@
 
 namespace TweakPHP\Client\Helpers;
 
-class Str{
+class Str
+{
     /**
      * Determine if a given string contains a given substring.
      *

--- a/src/Loaders/BaseLoader.php
+++ b/src/Loaders/BaseLoader.php
@@ -3,10 +3,10 @@
 namespace TweakPHP\Client\Loaders;
 
 use Psy\Configuration;
+use Psy\Shell;
 use Psy\VersionUpdater\Checker;
 use TweakPHP\Client\OutputModifiers\CustomOutputModifier;
 use TweakPHP\Client\Tinker;
-use Psy\Shell;
 
 abstract class BaseLoader implements LoaderInterface
 {

--- a/src/Loaders/BaseLoader.php
+++ b/src/Loaders/BaseLoader.php
@@ -6,6 +6,7 @@ use Psy\Configuration;
 use Psy\VersionUpdater\Checker;
 use TweakPHP\Client\OutputModifiers\CustomOutputModifier;
 use TweakPHP\Client\Tinker;
+use Psy\Shell;
 
 abstract class BaseLoader implements LoaderInterface
 {
@@ -54,5 +55,10 @@ abstract class BaseLoader implements LoaderInterface
         $output = $this->tinker->execute($code);
 
         return trim($output);
+    }
+
+    protected function getShell(): Shell
+    {
+        return $this->tinker->getShell();
     }
 }

--- a/src/Loaders/LaravelLoader.php
+++ b/src/Loaders/LaravelLoader.php
@@ -7,7 +7,9 @@ use TweakPHP\Client\Helpers\ClassAliasAutoloader;
 class LaravelLoader extends ComposerLoader
 {
     private $app;
+
     private $loader;
+
     private $path;
 
     public static function supports(string $path): bool
@@ -16,11 +18,11 @@ class LaravelLoader extends ComposerLoader
     }
 
     public function init(): void
-    {   
+    {
         parent::init();
-        
+
         $this->loader = ClassAliasAutoloader::register(
-            $this->getShell(), $this->path."/vendor/composer/autoload_classmap.php"
+            $this->getShell(), $this->path.'/vendor/composer/autoload_classmap.php'
         );
     }
 

--- a/src/Loaders/LaravelLoader.php
+++ b/src/Loaders/LaravelLoader.php
@@ -2,13 +2,26 @@
 
 namespace TweakPHP\Client\Loaders;
 
+use TweakPHP\Client\Helpers\ClassAliasAutoloader;
+
 class LaravelLoader extends ComposerLoader
 {
     private $app;
+    private $loader;
+    private $path;
 
     public static function supports(string $path): bool
     {
         return file_exists($path.'/vendor/autoload.php') && file_exists($path.'/bootstrap/app.php');
+    }
+
+    public function init(): void
+    {   
+        parent::init();
+        
+        $this->loader = ClassAliasAutoloader::register(
+            $this->getShell(), $this->path."/vendor/composer/autoload_classmap.php"
+        );
     }
 
     public function __construct(string $path)
@@ -16,6 +29,16 @@ class LaravelLoader extends ComposerLoader
         parent::__construct($path);
         $this->app = require_once $path.'/bootstrap/app.php';
         $this->app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
+        $this->path = $path;
+    }
+
+    public function execute($phpCode): string
+    {
+        try {
+            return parent::execute($phpCode);
+        } finally {
+            $this->loader->unregister();
+        }
     }
 
     public function name(): string

--- a/src/Tinker.php
+++ b/src/Tinker.php
@@ -82,4 +82,9 @@ class Tinker
 
         return trim($output);
     }
+
+    public function getShell(): Shell
+    {
+        return $this->shell;
+    }
 }


### PR DESCRIPTION

I extract and add the same function that currently exists in Laravel's Tinker to automatically create class aliases.

I'm sending this PR to analyze whether it makes sense to implement this functionality and for possible adjustments to the code.

![image](https://github.com/user-attachments/assets/5daa38d8-9fff-4462-b862-f3156a841001)
