### PR TITLE
add: new loader "WordPressBedrock"

### DIFF
--- a/src/Loaders/WordPressBedrockLoader.php
+++ b/src/Loaders/WordPressBedrockLoader.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace TweakPHP\Client\Loaders;
+
+use Throwable;
+
+class WordPressLoader extends BaseLoader
+{
+    public static function supports(string $path): bool
+    {
+        return file_exists($path.'/web/wp/wp-load.php');
+    }
+
+    public function __construct(string $path)
+    {
+        require_once $path.'/web/wp/wp-load.php';
+        require_once $path.'/web/wp/wp-admin/includes/admin.php';
+        require_once $path.'/web/wp/wp-includes/pluggable.php';
+    }
+
+    public function name(): string
+    {
+        return 'WordPress - Bedrock';
+    }
+
+    public function version(): string
+    {
+        try {
+            if (function_exists('get_bloginfo')) {
+                return get_bloginfo('version');
+            }
+        } catch (Throwable $e) {
+            //
+        }
+
+        return '';
+    }
+}


### PR DESCRIPTION
Bedrock by Roots is a very popular WordPress boilerplate. But, it uses a different folder structure than WordPress. This PR aims to add a new loader that will enable support for Bedrock-based WordPress sites within tweakphp.


Ref: [roots.io/bedrock/](https://roots.io/bedrock/)