### PR TITLE
Prevent dynamic property assignment in Psy/Configuration

### DIFF
--- a/src/Psy/Configuration.php
+++ b/src/Psy/Configuration.php
@@ -4,6 +4,8 @@ namespace TweakPHP\Client\Psy;
 
 class Configuration extends \Psy\Configuration
 {
+    protected ?Presenter $presenter = null;
+
     public function getPresenter(): Presenter
     {
         if (! isset($this->presenter)) {


### PR DESCRIPTION
Hey there!

Because `Psy\Configuration->$presenter` is marked `private` (in the original package, not tweakphp/client), the assignment [in the extending Configuration.php](https://github.com/tweakphp/client/blob/8e3f588a89de86e1055d22f6a862123992db7973/src/Psy/Configuration.php#L10) from this project causes a deprecation warning.

I've added a redeclaration of the $presenter property to avoid this. I made it a `protected` property to avoid a similar issue for any future extending classes.