### PR TITLE
Add support for plain PHP projects

### DIFF
--- a/index.php
+++ b/index.php
@@ -13,10 +13,10 @@ if (count($arguments) < 3) {
 }
 
 $customLoader = Cli::getArgument('loader');
-$loader = Loader::load($arguments[1], $customLoader);
+$loader = Loader::load($arguments[1], $customLoader ?: null);
 
 if ($loader === null) {
-    echo 'Invalid path'.PHP_EOL;
+    echo 'No supported project found. Make sure the path contains a Composer project (vendor/autoload.php).'.PHP_EOL;
     exit(1);
 }
 

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -6,6 +6,7 @@ use TweakPHP\Client\Loaders\ComposerLoader;
 use TweakPHP\Client\Loaders\LaravelLoader;
 use TweakPHP\Client\Loaders\LoaderInterface;
 use TweakPHP\Client\Loaders\PimcoreLoader;
+use TweakPHP\Client\Loaders\PlainPhpLoader;
 use TweakPHP\Client\Loaders\SymfonyLoader;
 use TweakPHP\Client\Loaders\WordPressLoader;
 
@@ -42,6 +43,10 @@ class Loader
 
         if (ComposerLoader::supports($path)) {
             return new ComposerLoader($path);
+        }
+
+        if (PlainPhpLoader::supports($path)) {
+            return new PlainPhpLoader($path);
         }
 
         return null;

--- a/src/Loaders/BaseLoader.php
+++ b/src/Loaders/BaseLoader.php
@@ -41,6 +41,11 @@ abstract class BaseLoader implements LoaderInterface
         return $this->tinker->execute($code);
     }
 
+    public function executeStreaming(string $code): void
+    {
+        $this->tinker->executeStreaming($code);
+    }
+
     public function casters(): array
     {
         return [];

--- a/src/Loaders/LoaderInterface.php
+++ b/src/Loaders/LoaderInterface.php
@@ -14,5 +14,7 @@ interface LoaderInterface
 
     public function execute(string $code): array;
 
+    public function executeStreaming(string $code): void;
+
     public function casters(): array;
 }

--- a/src/Loaders/PlainPhpLoader.php
+++ b/src/Loaders/PlainPhpLoader.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace TweakPHP\Client\Loaders;
+
+class PlainPhpLoader extends BaseLoader
+{
+    public static function supports(string $path): bool
+    {
+        return is_dir($path);
+    }
+
+    public function __construct(string $path)
+    {
+        chdir($path);
+    }
+
+    public function name(): string
+    {
+        return 'PHP';
+    }
+
+    public function version(): string
+    {
+        return '';
+    }
+}


### PR DESCRIPTION
- add a PlainPhpLoader that detects Composer-based plain PHP projects
- update loader resolution to fall back to PlainPhpLoader when framework loaders do not match
- improve CLI error messaging when no supported project is found